### PR TITLE
Add new options to parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ sensor:
   name: Engineering Feed
   feed_url: 'https://www.sciencedaily.com/rss/matter_energy/engineering.xml'
   date_format: '%a, %b %d %I:%M %p'
+  remove_image_from_summary: true
   inclusions:
     - title
     - link
@@ -48,6 +49,7 @@ key | description
 **show_topn (Optional)** | fetch how many entres from rss source，if not set then fetch all
 **inclusions (Optional)** | List of fields to include from populating the list
 **exclusions (Optional)** | List of fields to exclude from populating the list
+**remove_image_from_summary (Optional)** | `true/false` Remove the image tag from the summary
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ key | description
 **date_format (Optional)** | strftime date format for date strings **Default** `%a, %b %d %I:%M %p`
 **filter (Optional)** | `topn/hours/time` select how to filter entries. `topn` returns n number of entries. `hours` returns entries published after number of hours back. `time` allows for templating a date/time to return entries after.
 **filter_value (Optional)** | used with filter to set the value
-**show_topn (Optional)** | fetch how many entres from rss source，if not set then fetch all
 **inclusions (Optional)** | List of fields to include from populating the list
 **exclusions (Optional)** | List of fields to exclude from populating the list
 **remove_image_from_summary (Optional)** | `true/false` Remove the image tag from the summary

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ key | description
 **name (Required)** | Name your feed
 **feed_url (Required)** | The RSS feed URL
 **date_format (Optional)** | strftime date format for date strings **Default** `%a, %b %d %I:%M %p`
+**filter (Optional)** | `topn/hours/time` select how to filter entries. `topn` returns n number of entries. `hours` returns entries published after number of hours back. `time` allows for templating a date/time to return entries after.
+**filter_value (Optional)** | used with filter to set the value
 **show_topn (Optional)** | fetch how many entres from rss source，if not set then fetch all
 **inclusions (Optional)** | List of fields to include from populating the list
 **exclusions (Optional)** | List of fields to exclude from populating the list


### PR DESCRIPTION
This change adds a few options for how to return the feed.
There is an option to remove the image from the summary attribute to allow for a cleaner output since the image can be parsed to a separate field.
There are also now options on how to filter the number of results by time rather than a static "n" number.