### PR TITLE
SensorEntity is now in homeassistant.components.sensor

### DIFF
--- a/custom_components/feedparser/sensor.py
+++ b/custom_components/feedparser/sensor.py
@@ -6,7 +6,7 @@ import feedparser
 import voluptuous as vol
 from datetime import timedelta
 from dateutil import parser
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import SensorEntity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
@@ -56,7 +56,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     )
 
 
-class FeedParserSensor(Entity):
+class FeedParserSensor(SensorEntity):
     def __init__(
         self,
         feed: str,

--- a/custom_components/feedparser/sensor.py
+++ b/custom_components/feedparser/sensor.py
@@ -6,7 +6,7 @@ import feedparser
 import voluptuous as vol
 from datetime import timedelta
 from dateutil import parser
-from homeassistant.helpers.entity import SensorEntity
+from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
@@ -56,7 +56,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     )
 
 
-class FeedParserSensor(SensorEntity):
+class FeedParserSensor(Entity):
     def __init__(
         self,
         feed: str,


### PR DESCRIPTION
When upgrading to Home Assistant 2021.4.0, the feedparser did not work anymore and gave an error about SensorEntity.
SensorEntity is now in homeassistant.components.sensor