### PR TITLE
Bump feedparser version to 6.0.8

### DIFF
--- a/custom_components/feedparser/manifest.json
+++ b/custom_components/feedparser/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/custom-components/feedparser/blob/master/README.md",
   "dependencies": [],
   "codeowners": ["@iantrich"],
-  "requirements": ["feedparser==6.0.2"]
+  "requirements": ["feedparser==6.0.8"]
 }


### PR DESCRIPTION
update feedparser to accommodate HA 2021.7.0 which have python 3.9