### PR TITLE
Ability to convert dates into local timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ key | description
 **name (Required)** | Name your feed
 **feed_url (Required)** | The RSS feed URL
 **date_format (Optional)** | strftime date format for date strings **Default** `%a, %b %d %I:%M %p`
+**local_time (Optional)** | Whether to convert date into local time **Default** false
 **show_topn (Optional)** | fetch how many entres from rss source，if not set then fetch all
 **inclusions (Optional)** | List of fields to include from populating the list
 **exclusions (Optional)** | List of fields to exclude from populating the list

--- a/custom_components/feedparser/sensor.py
+++ b/custom_components/feedparser/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import SensorEntity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
+import homeassistant.util.dt as dt
 
 __version__ = "0.1.2"
 
@@ -20,6 +21,7 @@ CONF_DATE_FORMAT = "date_format"
 CONF_INCLUSIONS = "inclusions"
 CONF_EXCLUSIONS = "exclusions"
 CONF_SHOW_TOPN = "show_topn"
+CONF_LOCAL_TIME  = 'local_time'
 
 DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
 
@@ -35,6 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_SHOW_TOPN, default=9999): cv.positive_int,
         vol.Optional(CONF_INCLUSIONS, default=[]): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_EXCLUSIONS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_LOCAL_TIME, default=False): cv.boolean,
     }
 )
 
@@ -47,6 +50,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 feed=config[CONF_FEED_URL],
                 name=config[CONF_NAME],
                 date_format=config[CONF_DATE_FORMAT],
+                local_time=config[CONF_LOCAL_TIME],
                 show_topn=config[CONF_SHOW_TOPN],
                 inclusions=config[CONF_INCLUSIONS],
                 exclusions=config[CONF_EXCLUSIONS],
@@ -63,12 +67,14 @@ class FeedParserSensor(SensorEntity):
         name: str,
         date_format: str,
         show_topn: str,
+        local_time: bool,
         exclusions: str,
         inclusions: str,
     ):
         self._feed = feed
         self._name = name
         self._date_format = date_format
+        self._local_time = local_time
         self._show_topn = show_topn
         self._inclusions = inclusions
         self._exclusions = exclusions
@@ -99,7 +105,11 @@ class FeedParserSensor(SensorEntity):
                     ):
                         continue
                     if key in ["published", "updated", "created", "expired"]:
-                        value = parser.parse(value).strftime(self._date_format)
+                        value = parser.parse(value)
+                        if self._local_time:
+                            value = dt.as_local(value)
+                        value = value.strftime(self._date_format)
+
 
                     entryValue[key] = value
 


### PR DESCRIPTION
Hi,
I've been running this modification for a while.

One of my local feeds uses UTC in their RSS feed and I'm in UTC+10, this addition allows for the times to be converted to the users configured timezone in home assistant. 

It's a simple enough modification that I thought it would be worth making a pull request.