### PR TITLE
Add IoT class to manifest

### DIFF
--- a/custom_components/feedparser/manifest.json
+++ b/custom_components/feedparser/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/custom-components/feedparser/blob/master/README.md",
   "dependencies": [],
   "codeowners": ["@iantrich"],
-  "requirements": ["feedparser==6.0.8"]
+  "requirements": ["feedparser==6.0.8"],
+  "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
validation job is failing due to a missing IoT class