### PR TITLE
Add HTTP headers to the request

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
             voluptuous-stubs,
             types-python-dateutil,
             types-PyYAML,
+            types-requests,
           ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,13 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11.0"
-dependencies = ["python-dateutil", "feedparser==6.0.10", "homeassistant"]
+dependencies = [
+  "feedparser==6.0.10",
+  "homeassistant",
+  "python-dateutil",
+  "requests-file",
+  "requests",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -34,6 +40,7 @@ dev = [
   "ruff",
   "types-python-dateutil",
   "types-PyYAML",
+  "types-requests",
   "voluptuous-stubs",
   "pyyaml",
 
@@ -97,11 +104,11 @@ select = [
 
 # Q000,ANN,PT009,D,E501,
 ignore = [
-  "D107",    # Missing docstring in __init__
-  "FBT001",  # Boolean positional arg in function definition
-  "D203",    # 1 blank line required before class docstring
-  "D213",    # Multi-line docstring summary should start at the first line
-  "FBT001"   # Boolean positional argument in function definition
+  "D107",   # Missing docstring in __init__
+  "FBT001", # Boolean positional arg in function definition
+  "D203",   # 1 blank line required before class docstring
+  "D213",   # Multi-line docstring summary should start at the first line
+  "FBT001", # Boolean positional argument in function definition
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -93,3 +93,14 @@ TEST_FEEDS = [
 DEFAULT_EXCLUSIONS: list[str] = []
 DEFAULT_INCLUSIONS = ["image", "title", "link", "published"]
 DATE_FORMAT = "%a, %d %b %Y %H:%M:%S UTC%z"
+
+URLS_HEADERS_REQUIRED = [
+    {
+        "name": "elcomercio_gijon",
+        "url": "https://www.elcomercio.es/rss/2.0/?section=gijon",
+    },
+    {
+        "name": "nasdaq_options",
+        "url": "https://www.nasdaq.com/feed/rssoutbound?category=Options",
+    },
+]

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import feedparser
 import pytest
-from constants import DATE_FORMAT
+from constants import DATE_FORMAT, URLS_HEADERS_REQUIRED
 from feedsource import FeedSource
 
 from custom_components.feedparser.sensor import (
@@ -157,3 +157,24 @@ def test_check_duplicates(feed_sensor: FeedParserSensor) -> None:
     feed_sensor.update()
     after_second_update = len(feed_sensor.feed_entries)
     assert after_first_update == after_second_update
+
+
+@pytest.mark.parametrize(
+    "online_feed",
+    URLS_HEADERS_REQUIRED,
+    ids=lambda feed_url: feed_url["name"],
+)
+def test_fetch_data_headers_required(online_feed: dict) -> None:
+    """Test fetching feed from remote server that requires request with headers."""
+    feed_sensor = FeedParserSensor(
+        feed=online_feed["url"],
+        name=online_feed["name"],
+        date_format=DATE_FORMAT,
+        local_time=False,
+        show_topn=9999,
+        inclusions=["image", "title", "link", "published"],
+        exclusions=[],
+        scan_interval=DEFAULT_SCAN_INTERVAL,
+    )
+    feed_sensor.update()
+    assert feed_sensor.feed_entries


### PR DESCRIPTION
Fixes #112

Some HTTP servers require User-Agent to be present in the request header. This patch adds it to each request that the integration does.

I also found out that elcomercio.es does throws 403 in case User-Agent is not present in the header or if `"feedparser" in headers["User-Agent"]`. Which is strange. Therefore the User-Agent value contains `feed-parser` instead of simple `feedparser`.