### PR TITLE
feat: modernize feedparser integration for HA 2026 standards

### DIFF
--- a/custom_components/feedparser/manifest.json
+++ b/custom_components/feedparser/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/custom-components/feedparser/blob/master/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/custom-components/feedparser/issues",
-  "requirements": ["feedparser==6.0.11", "python-dateutil", "requests-file", "requests"],
-  "version": "0.1.11"
+  "requirements": ["feedparser==6.0.11", "python-dateutil", "aiohttp>=3.9.0"],
+  "version": "0.2.0"
 }

--- a/custom_components/feedparser/sensor.py
+++ b/custom_components/feedparser/sensor.py
@@ -1,33 +1,33 @@
 """Feedparser sensor."""
 from __future__ import annotations
 
+import asyncio
 import email.utils
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
+from urllib.parse import urlparse
 
+import aiohttp
 import feedparser  # type: ignore[import]
 import homeassistant.helpers.config_validation as cv
-import requests
 import voluptuous as vol
 from dateutil import parser
 from feedparser import FeedParserDict
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
-from requests_file import FileAdapter
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
-    from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+    pass
 
-__version__ = "0.1.11"
+__version__ = "0.2.0"
 
 COMPONENT_REPO = "https://github.com/custom-components/feedparser/"
-
-REQUIREMENTS = ["feedparser"]
 
 CONF_FEED_URL = "feed_url"
 CONF_DATE_FORMAT = "date_format"
@@ -41,6 +41,9 @@ DEFAULT_DATE_FORMAT = "%a, %b %d %I:%M %p"
 DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
 DEFAULT_THUMBNAIL = "https://www.home-assistant.io/images/favicon-192x192-full.png"
 DEFAULT_TOPN = 9999
+DEFAULT_TIMEOUT = 30
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY = 2
 USER_AGENT = f"Home Assistant Feed-parser Integration {__version__}"
 IMAGE_REGEX = r"<img.+?src=\"(.+?)\".+?>"
 
@@ -61,8 +64,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+class FeedEntryDict(TypedDict, total=False):
+    """Type definition for feed entry dictionary."""
+
+    title: str
+    link: str
+    description: str
+    summary: str
+    published: str
+    updated: str
+    created: str
+    expired: str
+    image: str
+    author: str
+    category: str
+
+
 async def async_setup_platform(
-    hass: HomeAssistant,  # noqa: ARG001
+    hass: HomeAssistant,
     config: ConfigType,
     async_add_devices: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,  # noqa: ARG001
@@ -71,6 +90,7 @@ async def async_setup_platform(
     async_add_devices(
         [
             FeedParserSensor(
+                hass=hass,
                 feed=config[CONF_FEED_URL],
                 name=config[CONF_NAME],
                 date_format=config[CONF_DATE_FORMAT],
@@ -89,12 +109,14 @@ async def async_setup_platform(
 class FeedParserSensor(SensorEntity):
     """Representation of a Feedparser sensor."""
 
-    # force update the entity since the number of feed entries does not necessarily
-    # change, but we still want to update the extra_state_attributes
     _attr_force_update = True
+    _attr_icon = "mdi:rss"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = "entries"
 
     def __init__(
         self: FeedParserSensor,
+        hass: HomeAssistant,
         feed: str,
         name: str,
         date_format: str,
@@ -106,9 +128,9 @@ class FeedParserSensor(SensorEntity):
         local_time: bool,
     ) -> None:
         """Initialize the Feedparser sensor."""
+        self.hass = hass
         self._feed = feed
         self._attr_name = name
-        self._attr_icon = "mdi:rss"
         self._date_format = date_format
         self._show_topn: int = show_topn
         self._remove_summary_image = remove_summary_image
@@ -116,10 +138,27 @@ class FeedParserSensor(SensorEntity):
         self._exclusions = exclusions
         self._scan_interval = scan_interval
         self._local_time = local_time
-        self._entries: list[dict[str, str]] = []
+        self._entries: list[FeedEntryDict] = []
         self._attr_extra_state_attributes = {"entries": self._entries}
         self._attr_attribution = "Data retrieved using RSS feedparser"
+        self._session: aiohttp.ClientSession | None = None
+        self._available = True
         _LOGGER.debug("Feed %s: FeedParserSensor initialized - %s", self.name, self)
+
+    async def async_added_to_hass(self: FeedParserSensor) -> None:
+        """When entity is added to hass."""
+        # Create session when entity is added
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+            headers={"User-Agent": USER_AGENT},
+        )
+
+    async def async_will_remove_from_hass(self: FeedParserSensor) -> None:
+        """When entity will be removed from hass."""
+        # Close session when entity is removed
+        if self._session:
+            await self._session.close()
+            self._session = None
 
     def __repr__(self: FeedParserSensor) -> str:
         """Return the representation."""
@@ -132,167 +171,328 @@ class FeedParserSensor(SensorEntity):
             f'local_time={self._local_time}, date_format="{self._date_format}")'
         )
 
-    def update(self: FeedParserSensor) -> None:
+    @property
+    def available(self: FeedParserSensor) -> bool:
+        """Return if entity is available."""
+        return self._available
+
+    async def async_update(self: FeedParserSensor) -> None:
         """Parse the feed and update the state of the sensor."""
+        if not self._session:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+                headers={"User-Agent": USER_AGENT},
+            )
+
         _LOGGER.debug("Feed %s: Polling feed data from %s", self.name, self._feed)
-        s: requests.Session = requests.Session()
-        s.mount("file://", FileAdapter())
-        s.headers.update({"User-Agent": USER_AGENT})
-        res: requests.Response = s.get(self._feed)
-        res.raise_for_status()
-        parsed_feed: FeedParserDict = feedparser.parse(res.text)
+
+        # Check if feed URL is a file:// URL (local file)
+        parsed_url = urlparse(self._feed)
+        if parsed_url.scheme == "file":
+            # For local files, read synchronously (feedparser handles this)
+            try:
+                with open(parsed_url.path, encoding="utf-8") as file:
+                    feed_text = file.read()
+                parsed_feed = feedparser.parse(feed_text)
+            except (OSError, UnicodeDecodeError) as err:
+                _LOGGER.error(
+                    "Feed %s: Error reading local file %s: %s",
+                    self.name,
+                    parsed_url.path,
+                    err,
+                )
+                self._available = False
+                self._attr_native_value = None
+                return
+        else:
+            # For HTTP/HTTPS URLs, use async fetch with retry logic
+            feed_text = await self._fetch_feed_with_retry()
+            if not feed_text:
+                self._available = False
+                self._attr_native_value = None
+                return
+            parsed_feed = feedparser.parse(feed_text)
+
+        # Check for feed parsing errors
+        if parsed_feed.bozo and parsed_feed.bozo_exception:
+            _LOGGER.warning(
+                "Feed %s: Feed parsing warning: %s",
+                self.name,
+                parsed_feed.bozo_exception,
+            )
 
         if not parsed_feed.entries:
             self._attr_native_value = None
-            _LOGGER.warning("Feed %s: No data received.", self.name)
+            self._available = True
+            _LOGGER.warning("Feed %s: No entries found in feed.", self.name)
             return
 
         _LOGGER.debug("Feed %s: Feed data fetched successfully", self.name)
-        # set the sensor value to the amount of entries
-        self._attr_native_value = (
-            self._show_topn
-            if len(parsed_feed.entries) > self._show_topn
-            else len(parsed_feed.entries)
-        )
+
+        # Validate entries have required fields
+        valid_entries = [
+            entry
+            for entry in parsed_feed.entries
+            if entry.get("title") or entry.get("link")
+        ]
+
+        if not valid_entries:
+            _LOGGER.warning(
+                "Feed %s: No valid entries found (missing title or link).",
+                self.name,
+            )
+            self._attr_native_value = None
+            self._available = True
+            return
+
+        # Set the sensor value to the amount of entries
+        entry_count = min(len(valid_entries), self._show_topn)
+        self._attr_native_value = entry_count
+
         _LOGGER.debug(
-            "Feed %s: %s entries is going to be added to the sensor",
+            "Feed %s: %s entries will be added to the sensor",
             self.name,
-            self.native_value,
+            entry_count,
         )
-        self._entries.clear()  # clear the entries to avoid duplicates
-        self._entries.extend(self._generate_entries(parsed_feed))
+
+        # Clear and regenerate entries
+        self._entries.clear()
+        self._entries.extend(self._generate_entries(valid_entries[:entry_count]))
+        self._available = True
+
         _LOGGER.debug(
             "Feed %s: Sensor state updated - %s entries",
             self.name,
             len(self.feed_entries),
         )
 
+    async def _fetch_feed_with_retry(self: FeedParserSensor) -> str | None:
+        """Fetch feed with retry logic and exponential backoff."""
+        if not self._session:
+            return None
+
+        last_exception: Exception | None = None
+
+        for attempt in range(DEFAULT_MAX_RETRIES):
+            try:
+                async with self._session.get(self._feed) as response:
+                    response.raise_for_status()
+                    return await response.text()
+
+            except asyncio.TimeoutError as err:
+                last_exception = err
+                _LOGGER.warning(
+                    "Feed %s: Timeout fetching feed (attempt %d/%d): %s",
+                    self.name,
+                    attempt + 1,
+                    DEFAULT_MAX_RETRIES,
+                    err,
+                )
+
+            except aiohttp.ClientError as err:
+                last_exception = err
+                _LOGGER.warning(
+                    "Feed %s: Client error fetching feed (attempt %d/%d): %s",
+                    self.name,
+                    attempt + 1,
+                    DEFAULT_MAX_RETRIES,
+                    err,
+                )
+
+            except Exception as err:
+                last_exception = err
+                _LOGGER.error(
+                    "Feed %s: Unexpected error fetching feed (attempt %d/%d): %s",
+                    self.name,
+                    attempt + 1,
+                    DEFAULT_MAX_RETRIES,
+                    err,
+                )
+
+            # Wait before retry with exponential backoff
+            if attempt < DEFAULT_MAX_RETRIES - 1:
+                delay = DEFAULT_RETRY_DELAY * (2**attempt)
+                _LOGGER.debug(
+                    "Feed %s: Retrying in %d seconds...",
+                    self.name,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        _LOGGER.error(
+            "Feed %s: Failed to fetch feed after %d attempts: %s",
+            self.name,
+            DEFAULT_MAX_RETRIES,
+            last_exception,
+        )
+        return None
+
     def _generate_entries(
         self: FeedParserSensor,
-        parsed_feed: FeedParserDict,
-    ) -> list[dict[str, str]]:
+        feed_entries: list[FeedParserDict],
+    ) -> list[FeedEntryDict]:
+        """Generate sensor entries from feed entries."""
         return [
             self._generate_sensor_entry(feed_entry)
-            for feed_entry in parsed_feed.entries[
-                : self.native_value  # type: ignore[misc]
-            ]
+            for feed_entry in feed_entries
         ]
 
     def _generate_sensor_entry(
         self: FeedParserSensor,
         feed_entry: FeedParserDict,
-    ) -> dict[str, str]:
+    ) -> FeedEntryDict:
+        """Generate a sensor entry from a feed entry."""
         _LOGGER.debug("Feed %s: Generating sensor entry for %s", self.name, feed_entry)
-        sensor_entry = {}
+        sensor_entry: FeedEntryDict = {}
+
         for key, value in feed_entry.items():
+            # Skip if excluded or not in inclusions list
             if (
                 (self._inclusions and key not in self._inclusions)
                 or ("parsed" in key)
                 or (key in self._exclusions)
             ):
                 continue
-            if key in ["published", "updated", "created", "expired"]:
-                parsed_date: datetime = self._parse_date(value)
-                sensor_entry[key] = parsed_date.strftime(self._date_format)
-            elif key == "image":
-                sensor_entry["image"] = value.get("href")
-            else:
-                sensor_entry[key] = value
 
+            # Handle date fields
+            if key in ["published", "updated", "created", "expired"]:
+                try:
+                    parsed_date = self._parse_date(value)
+                    sensor_entry[key] = parsed_date.strftime(self._date_format)  # type: ignore[literal-required]
+                except (ValueError, TypeError) as err:
+                    _LOGGER.warning(
+                        "Feed %s: Error parsing date field %s: %s",
+                        self.name,
+                        key,
+                        err,
+                    )
+                    continue
+
+            # Handle image field
+            elif key == "image":
+                if isinstance(value, dict):
+                    sensor_entry["image"] = value.get("href", "")  # type: ignore[literal-required]
+                else:
+                    sensor_entry["image"] = str(value)  # type: ignore[literal-required]
+
+            # Handle other fields
+            else:
+                # Convert value to string if it's not already
+                if isinstance(value, (list, dict)):
+                    sensor_entry[key] = str(value)  # type: ignore[literal-required]
+                else:
+                    sensor_entry[key] = str(value) if value is not None else ""  # type: ignore[literal-required]
+
+        # Process image if in inclusions but not found
         if "image" in self._inclusions and "image" not in sensor_entry:
-            sensor_entry["image"] = self._process_image(feed_entry)
+            sensor_entry["image"] = self._process_image(feed_entry)  # type: ignore[literal-required]
+
+        # Process link if in inclusions but not found
         if (
             "link" in self._inclusions
             and "link" not in sensor_entry
             and (processed_link := self._process_link(feed_entry))
         ):
-            sensor_entry["link"] = processed_link
+            sensor_entry["link"] = processed_link  # type: ignore[literal-required]
+
+        # Remove images from summary if requested
         if self._remove_summary_image and "summary" in sensor_entry:
-            sensor_entry["summary"] = re.sub(
+            sensor_entry["summary"] = re.sub(  # type: ignore[literal-required]
                 IMAGE_REGEX,
                 "",
-                sensor_entry["summary"],
+                sensor_entry.get("summary", ""),
             )
+
         _LOGGER.debug("Feed %s: Generated sensor entry: %s", self.name, sensor_entry)
         return sensor_entry
 
-    def _parse_date(self: FeedParserSensor, date: str) -> datetime:
+    def _parse_date(self: FeedParserSensor, date: str | None) -> datetime:
+        """Parse a date string to datetime object."""
+        if not date:
+            raise ValueError("Date string is None or empty")
+
         try:
             parsed_time: datetime = email.utils.parsedate_to_datetime(date)
-        except ValueError:
-            _LOGGER.warning(
-                (
-                    "Feed %s: Unable to parse RFC-822 date from %s. "
-                    "This could be caused by incorrect pubDate format "
-                    "in the RSS feed or due to a leapp second"
-                ),
+        except (ValueError, TypeError):
+            _LOGGER.debug(
+                "Feed %s: Unable to parse RFC-822 date from %s, trying dateutil",
                 self.name,
                 date,
             )
-            # best effort to parse the date using dateutil
-            parsed_time = parser.parse(date)
-
-        if not parsed_time.tzinfo:
-            # best effort to parse the date using dateutil
-            parsed_time = parser.parse(date)
-            if not parsed_time.tzinfo:
+            # Fallback to dateutil parser
+            try:
+                parsed_time = parser.parse(date)
+            except (ValueError, TypeError) as err:
                 msg = (
                     f"Feed {self.name}: Unable to parse date {date}, "
                     "caused by an incorrect date format"
                 )
-                raise ValueError(msg)
-        if not parsed_time.tzname():
-            # replace tzinfo with UTC offset if tzinfo does not contain a TZ name
-            parsed_time = parsed_time.replace(
-                tzinfo=timezone(parsed_time.utcoffset()),  # type: ignore[arg-type]
-            )
+                raise ValueError(msg) from err
 
+        # Ensure timezone info is present
+        if not parsed_time.tzinfo:
+            # Try dateutil parser which might handle timezone better
+            try:
+                parsed_time = parser.parse(date)
+            except (ValueError, TypeError) as err:
+                msg = (
+                    f"Feed {self.name}: Unable to parse date {date} with timezone, "
+                    "caused by an incorrect date format"
+                )
+                raise ValueError(msg) from err
+
+        # Replace tzinfo with UTC offset if tzinfo doesn't have a TZ name
+        if parsed_time.tzinfo and not parsed_time.tzname():
+            offset = parsed_time.utcoffset()
+            if offset:
+                parsed_time = parsed_time.replace(tzinfo=timezone(offset))
+
+        # Convert to local time if requested
         if self._local_time:
             parsed_time = dt.as_local(parsed_time)
+
         _LOGGER.debug("Feed %s: Parsed date: %s", self.name, parsed_time)
         return parsed_time
 
     def _process_image(self: FeedParserSensor, feed_entry: FeedParserDict) -> str:
+        """Extract image URL from feed entry."""
+        # Check enclosures first
         if feed_entry.get("enclosures"):
             images = [
-                enc for enc in feed_entry["enclosures"] if enc.type.startswith("image/")
+                enc
+                for enc in feed_entry["enclosures"]
+                if enc.get("type", "").startswith("image/")
             ]
             if images:
-                # pick the first image found
-                return images[0]["href"]
-        elif "summary" in feed_entry:
-            images = re.findall(
-                IMAGE_REGEX,
-                feed_entry["summary"],
-            )
+                return images[0].get("href", DEFAULT_THUMBNAIL)
+
+        # Check summary for embedded images
+        if "summary" in feed_entry:
+            images = re.findall(IMAGE_REGEX, feed_entry["summary"])
             if images:
-                # pick the first image found
                 return images[0]
+
         _LOGGER.debug(
-            "Feed %s: Image is in inclusions, but no image was found for %s",
+            "Feed %s: Image is in inclusions, but no image was found for entry",
             self.name,
-            feed_entry,
         )
-        return DEFAULT_THUMBNAIL  # use default image if no image found
+        return DEFAULT_THUMBNAIL
 
     def _process_link(self: FeedParserSensor, feed_entry: FeedParserDict) -> str:
-        """Return link from feed entry."""
-        if "links" in feed_entry:
+        """Extract link from feed entry."""
+        if "links" in feed_entry and feed_entry["links"]:
             if len(feed_entry["links"]) > 1:
                 _LOGGER.debug(
-                    "Feed %s: More than one link found for %s. Using the first link.",
+                    "Feed %s: More than one link found. Using the first link.",
                     self.name,
-                    feed_entry,
                 )
-            return feed_entry["links"][0]["href"]
+            return feed_entry["links"][0].get("href", "")
         return ""
 
     @property
-    def feed_entries(self: FeedParserSensor) -> list[dict[str, str]]:
+    def feed_entries(self: FeedParserSensor) -> list[FeedEntryDict]:
         """Return feed entries."""
-        if hasattr(self, "_entries"):
-            return self._entries
-        return []
+        return self._entries
 
     @property
     def local_time(self: FeedParserSensor) -> bool:
@@ -305,6 +505,6 @@ class FeedParserSensor(SensorEntity):
         self._local_time = value
 
     @property
-    def extra_state_attributes(self: FeedParserSensor) -> dict[str, list]:
+    def extra_state_attributes(self: FeedParserSensor) -> dict[str, list[FeedEntryDict]]:
         """Return entity specific state attributes."""
         return {"entries": self.feed_entries}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "homeassistant.sensor.feedparser"
-version = "0.1.11"
+version = "0.2.0"
 description = "Home Assistant custom integration to parse RSS feeds"
 maintainers = [
   {name = "Ian Richardson", email = "iantrich@gmail.com"},
@@ -27,8 +27,7 @@ dependencies = [
   "feedparser==6.0.11",
   "homeassistant",
   "python-dateutil",
-  "requests-file",
-  "requests"
+  "aiohttp>=3.9.0"
 ]
 
 [project.optional-dependencies]
@@ -36,11 +35,12 @@ dev = [
   "black",
   "homeassistant-stubs",
   "pytest==8.0.0",
+  "pytest-asyncio>=0.21.0",
   "mypy",
   "ruff",
   "types-python-dateutil",
   "types-PyYAML",
-  "types-requests",
+  "types-aiohttp",
   "voluptuous-stubs",
   "pyyaml",
   "bumpver"
@@ -158,7 +158,7 @@ filterwarnings = [
 ]
 
 [tool.bumpver]
-current_version = "0.1.11"
+current_version = "0.2.0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Pytest configuration."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from constants import TEST_FEEDS
 from feedsource import FeedSource
@@ -40,9 +42,17 @@ def feed(request: pytest.FixtureRequest) -> FeedSource:
 
 
 @pytest.fixture()
-def feed_sensor(feed: FeedSource) -> FeedParserSensor:
+def mock_hass() -> MagicMock:
+    """Return a mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture()
+def feed_sensor(feed: FeedSource, mock_hass: MagicMock) -> FeedParserSensor:
     """Return feed sensor initialized with the local RSS feed."""
-    return FeedParserSensor(**feed.sensor_config_local_feed)
+    return FeedParserSensor(hass=mock_hass, **feed.sensor_config_local_feed)
 
 
 @pytest.fixture()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,6 +4,7 @@ import re
 from contextlib import nullcontext, suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import feedparser
 import pytest
@@ -21,15 +22,19 @@ if TYPE_CHECKING:
     import time
 
 
-def test_simple(feed_sensor: FeedParserSensor) -> None:
+@pytest.mark.asyncio
+async def test_simple(feed_sensor: FeedParserSensor) -> None:
     """Test simple."""
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
 
-def test_update_sensor(feed: FeedSource) -> None:
+@pytest.mark.asyncio
+async def test_update_sensor(feed: FeedSource, mock_hass: MagicMock) -> None:
     """Test instantiate sensor."""
+
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         feed=feed.path.absolute().as_uri(),
         name=feed.name,
         date_format=feed.sensor_config.date_format,
@@ -38,9 +43,9 @@ def test_update_sensor(feed: FeedSource) -> None:
         remove_summary_image=feed.sensor_config.remove_summary_image,
         inclusions=feed.sensor_config.inclusions,
         exclusions=feed.sensor_config.exclusions,
-        scan_interval=feed.sensor_config.scan_interval,
+        scan_interval=feed.sensor_config.scan_interval_timedelta,
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
     # assert that the sensor value is equal to the number of entries
@@ -91,10 +96,13 @@ def test_update_sensor(feed: FeedSource) -> None:
         ), "Duplicate images found"
 
 
-def test_update_sensor_with_topn(feed: FeedSource) -> None:
+@pytest.mark.asyncio
+async def test_update_sensor_with_topn(feed: FeedSource, mock_hass: MagicMock) -> None:
     """Test that the sensor stores only the topn entries."""
+
     show_topn = 1
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         feed=feed.path.absolute().as_uri(),
         name=feed.name,
         date_format=DATE_FORMAT,
@@ -105,7 +113,7 @@ def test_update_sensor_with_topn(feed: FeedSource) -> None:
         exclusions=[],
         scan_interval=DEFAULT_SCAN_INTERVAL,
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
     # assert that the sensor value is equal to the number of
@@ -118,14 +126,15 @@ def test_update_sensor_with_topn(feed: FeedSource) -> None:
     [True, False],
     ids=["local_time", "default_time"],
 )
-def test_update_sensor_entries_time(
+@pytest.mark.asyncio
+async def test_update_sensor_entries_time(
     feed: FeedSource,
     feed_sensor: FeedParserSensor,
     local_time: bool,
 ) -> None:
     """Test that the sensor converts the published date to local time."""
     feed_sensor.local_time = local_time
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
     # load the feed with feedparser
@@ -154,12 +163,13 @@ def test_update_sensor_entries_time(
     assert first_entry_time == first_sensor_entry_time
 
 
-def test_check_duplicates(feed_sensor: FeedParserSensor) -> None:
+@pytest.mark.asyncio
+async def test_check_duplicates(feed_sensor: FeedParserSensor) -> None:
     """Test that the sensor stores only unique entries."""
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.extra_state_attributes["entries"]
     after_first_update = len(feed_sensor.feed_entries)
-    feed_sensor.update()
+    await feed_sensor.async_update()
     after_second_update = len(feed_sensor.feed_entries)
     assert after_first_update == after_second_update
 
@@ -169,9 +179,15 @@ def test_check_duplicates(feed_sensor: FeedParserSensor) -> None:
     URLS_HEADERS_REQUIRED,
     ids=lambda feed_url: feed_url["name"],
 )
-def test_fetch_data_headers_required(online_feed: dict) -> None:
+@pytest.mark.asyncio
+async def test_fetch_data_headers_required(
+    online_feed: dict,
+    mock_hass: MagicMock,
+) -> None:
     """Test fetching feed from remote server that requires request with headers."""
+
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         feed=online_feed["url"],
         name=online_feed["name"],
         date_format=DATE_FORMAT,
@@ -182,19 +198,23 @@ def test_fetch_data_headers_required(online_feed: dict) -> None:
         exclusions=[],
         scan_interval=DEFAULT_SCAN_INTERVAL,
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
 
-def test_remove_summary_image(
+@pytest.mark.asyncio
+async def test_remove_summary_image(
     feed_with_image_in_summary: FeedSource,
+    mock_hass: MagicMock,
 ) -> None:
     """Test that the sensor removes the image from the summary."""
+
     feed = feed_with_image_in_summary
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         **feed.sensor_config_local_feed | {"remove_summary_image": False},
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
     # assert that the sensor does not remove the image from the summary
@@ -204,22 +224,26 @@ def test_remove_summary_image(
     )
 
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         **feed.sensor_config_local_feed | {"remove_summary_image": True},
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
 
     with nullcontext() if feed.all_entries_have_summary else suppress(KeyError):
         assert all("img" not in e["summary"] for e in feed_sensor.feed_entries)
 
 
-def test_image_not_in_entries(feed: FeedSource) -> None:
+@pytest.mark.asyncio
+async def test_image_not_in_entries(feed: FeedSource, mock_hass: MagicMock) -> None:
     """Test that the sensor does not include the image in any feed entry."""
+
     # keep only the title in the inclusions
     feed_sensor = FeedParserSensor(
+        hass=mock_hass,
         **feed.sensor_config_local_feed | {"inclusions": ["title"]},
     )
-    feed_sensor.update()
+    await feed_sensor.async_update()
     assert feed_sensor.feed_entries
     # assert that the sensor does not include the image in its feed entries
     assert all("image" not in e for e in feed_sensor.feed_entries)


### PR DESCRIPTION
Convert integration to async/await pattern and improve reliability

Changes:
- Replace synchronous requests with async aiohttp for non-blocking I/O
- Add retry logic with exponential backoff (3 retries, 2s base delay)
- Add comprehensive error handling for network failures and malformed feeds
- Add 30-second timeout to prevent hanging during HA shutdown
- Add EntityCategory.DIAGNOSTIC and native_unit_of_measurement
- Update tests to use async patterns with pytest-asyncio

Dependencies: Replace requests with aiohttp>=3.9.0
Version bump: 0.1.11 → 0.2.0